### PR TITLE
Fix FrameBlock::updateShape method

### DIFF
--- a/src/main/java/com/starfish_studios/bbb/block/FrameBlock.java
+++ b/src/main/java/com/starfish_studios/bbb/block/FrameBlock.java
@@ -215,10 +215,10 @@ public class FrameBlock extends Block implements SimpleWaterloggedBlock {
         }
         var facing = state.getValue(FACING);
         return state
-                .setValue(TOP, checkConnection(level, currentPos, Direction.DOWN))
-                .setValue(BOTTOM, checkConnection(level, currentPos, Direction.UP))
-                .setValue(LEFT, checkConnection(level, currentPos, facing.getCounterClockWise()))
-                .setValue(RIGHT, checkConnection(level, currentPos, facing.getClockWise()));
+                .setValue(TOP, checkConnection(level, currentPos, Direction.UP))
+                .setValue(BOTTOM, checkConnection(level, currentPos, Direction.DOWN))
+                .setValue(LEFT, checkConnection(level, currentPos, facing.getClockWise()))
+                .setValue(RIGHT, checkConnection(level, currentPos, facing.getCounterClockWise()));
     }
 
     @Override
@@ -247,11 +247,11 @@ public class FrameBlock extends Block implements SimpleWaterloggedBlock {
     }
 
     private static boolean checkConnection(LevelAccessor level, BlockPos pos, Direction direction) {
-        var relativePos = pos.relative(direction.getOpposite());
+        var relativePos = pos.relative(direction);
         var state = level.getBlockState(relativePos);
         boolean validConnection = state.is(BBBTags.BBBBlockTags.FRAMES)
                 || state.is(BBBTags.BBBBlockTags.STONE_FRAMES)
-                || state.isFaceSturdy(level, relativePos, direction);
+                || state.isFaceSturdy(level, relativePos, direction.getOpposite());
         return !validConnection;
     }
 }


### PR DESCRIPTION
Fix #6 by providing non-null `BlockGetter` and `BlockPos` values to `state.isFaceSturdy` in `FrameBlock::checkConnection` (formerly `FrameBlock::validConnection`).
Make it so `checkConnection` only checks the adjacent face of the neighboring block.
Invert the return value of `checkConnection` inside the function body, because every use of that function was already inverted anyway.
Optimize and inline `getConnections`.