### PR TITLE
FacingSlabBlock extends SlabBlock instead of Block

### DIFF
--- a/src/main/java/com/starfish_studios/bbb/block/FacingSlabBlock.java
+++ b/src/main/java/com/starfish_studios/bbb/block/FacingSlabBlock.java
@@ -2,22 +2,19 @@ package com.starfish_studios.bbb.block;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.SimpleWaterloggedBlock;
+import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.*;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class FacingSlabBlock extends Block implements SimpleWaterloggedBlock {
+public class FacingSlabBlock extends SlabBlock {
     public static final EnumProperty<SlabType> TYPE = BlockStateProperties.SLAB_TYPE;
     public static final DirectionProperty FACING = BlockStateProperties.FACING;
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -88,30 +85,6 @@ public class FacingSlabBlock extends Block implements SimpleWaterloggedBlock {
     public boolean canBeReplaced(BlockState blockState, BlockPlaceContext blockPlaceContext) {
         if (blockState.getValue(FACING) != blockPlaceContext.getClickedFace()) return false;
         return blockPlaceContext.getItemInHand().is(this.asItem()) && blockState.getValue(TYPE) != SlabType.DOUBLE || super.canBeReplaced(blockState, blockPlaceContext);
-    }
-
-    @Override
-    public FluidState getFluidState(BlockState blockState) {
-        return blockState.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(blockState);
-    }
-
-    @Override
-    public boolean placeLiquid(LevelAccessor levelAccessor, BlockPos blockPos, BlockState blockState, FluidState fluidState) {
-        return blockState.getValue(TYPE) != SlabType.DOUBLE && SimpleWaterloggedBlock.super.placeLiquid(levelAccessor, blockPos, blockState, fluidState);
-    }
-
-    @Override
-    public boolean canPlaceLiquid(BlockGetter blockGetter, BlockPos blockPos, BlockState blockState, Fluid fluid) {
-        return blockState.getValue(TYPE) != SlabType.DOUBLE && SimpleWaterloggedBlock.super.canPlaceLiquid(blockGetter, blockPos, blockState, fluid);
-    }
-
-    @Override
-    public BlockState updateShape(BlockState blockState, Direction direction, BlockState blockState2, LevelAccessor levelAccessor, BlockPos blockPos, BlockPos blockPos2) {
-        if (blockState.getValue(WATERLOGGED)) {
-            levelAccessor.scheduleTick(blockPos, Fluids.WATER, Fluids.WATER.getTickDelay(levelAccessor));
-        }
-
-        return super.updateShape(blockState, direction, blockState2, levelAccessor, blockPos, blockPos2);
     }
 
     @Override


### PR DESCRIPTION
as title.
in current, FacingSlabBlock rewrites most of functionality of SlabBlock, so should be better just extend the class instead.
fixes compatibility with [Andrew6rant/Auto-Slabs](https://github.com/Andrew6rant/Auto-Slabs).

unfortunately, it breaks with AutoSlabs in other way if I merge it to arch/1.20.1 branch, I'm not sure about that.